### PR TITLE
Token auth for job

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.1.1
 description: Kubernetes Operator for OTC RDS
 name: otc-rds-operator
 type: application
-version: 0.1.1
+version: 0.1.2
 sources:
   - https://github.com/eumel8/otc-rds-operator
 maintainers:

--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -9,6 +9,7 @@ metadata:
     {{- include "otc-rds-operator.labels" . | nindent 4 }}
 data:
   OS_PROJECT_NAME: {{ .Values.otc.project_name | default "eu-de" | b64enc | quote }}
+  OS_PROJECT_ID: {{ .Values.otc.project_id | default "7c3ec0b3db5f476990043258670caf82" | b64enc | quote }}
   OS_REGION_NAME: {{ .Values.otc.region_name | default "eu-de" | b64enc | quote }}
   OS_AUTH_URL: {{ .Values.otc.auth_url | default "https://iam.eu-de.otc.t-systems.com:443/v3" | b64enc | quote }}
   OS_IDENTITY_API_VERSION: {{ .Values.otc.api_version | default "3" | b64enc | quote }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -29,6 +29,7 @@ otc: {}
 #   api_version: "3"
 #   region: eu-de
 #   project_name: eu-de
+#   project_id: 7c3ec0b3db5f476990043258670caf82
 #   domain_name: OTC-EU-DE-000000000010000000001
 #   username: user
 #   password: password

--- a/pkg/controller/job.go
+++ b/pkg/controller/job.go
@@ -3,7 +3,6 @@ package controller
 import (
 	// "github.com/davecgh/go-spew/spew"
 	// dump structs with spew.Dump(opts)
-	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 
 	rds "github.com/eumel8/otc-rds-operator/pkg/rds"
 	rdsv1alpha1 "github.com/eumel8/otc-rds-operator/pkg/rds/v1alpha1"
@@ -19,7 +18,8 @@ var (
 	readonly   = bool(true)
 )
 
-func createJob(newRds *rdsv1alpha1.Rds, opts golangsdk.AuthOptions) *batchv1.Job {
+func createJob(newRds *rdsv1alpha1.Rds, endpoint string, token string) *batchv1.Job {
+	// func createJob(newRds *rdsv1alpha1.Rds, opts golangsdk.AuthOptions) *batchv1.Job {
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      newRds.ObjectMeta.Name,
@@ -32,11 +32,11 @@ func createJob(newRds *rdsv1alpha1.Rds, opts golangsdk.AuthOptions) *batchv1.Job
 				),
 			},
 		},
-		Spec: createJobSpec(newRds.Name, newRds.Namespace, opts),
+		Spec: createJobSpec(newRds.Name, newRds.Namespace, endpoint, token),
 	}
 }
 
-func createJobSpec(name string, namespace string, opts golangsdk.AuthOptions) batchv1.JobSpec {
+func createJobSpec(name string, namespace string, endpoint string, token string) batchv1.JobSpec {
 	return batchv1.JobSpec{
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
@@ -64,24 +64,12 @@ func createJobSpec(name string, namespace string, opts golangsdk.AuthOptions) ba
 								Value: name,
 							},
 							{
-								Name:  "OS_USERNAME",
-								Value: opts.Username,
-							},
-							{
-								Name:  "OS_PASSWORD",
-								Value: opts.Password,
+								Name:  "OS_TOKEN",
+								Value: token,
 							},
 							{
 								Name:  "OS_AUTH_URL",
-								Value: opts.IdentityEndpoint,
-							},
-							{
-								Name:  "OS_USER_DOMAIN_NAME",
-								Value: opts.DomainName,
-							},
-							{
-								Name:  "OS_PROJECT_NAME",
-								Value: opts.TenantName,
+								Value: endpoint,
 							},
 						},
 					},
@@ -103,24 +91,12 @@ func createJobSpec(name string, namespace string, opts golangsdk.AuthOptions) ba
 								Value: name,
 							},
 							{
-								Name:  "OS_USERNAME",
-								Value: opts.Username,
-							},
-							{
-								Name:  "OS_PASSWORD",
-								Value: opts.Password,
+								Name:  "OS_TOKEN",
+								Value: token,
 							},
 							{
 								Name:  "OS_AUTH_URL",
-								Value: opts.IdentityEndpoint,
-							},
-							{
-								Name:  "OS_USER_DOMAIN_NAME",
-								Value: opts.DomainName,
-							},
-							{
-								Name:  "OS_PROJECT_NAME",
-								Value: opts.TenantName,
+								Value: endpoint,
 							},
 						},
 					},

--- a/pkg/controller/resource.go
+++ b/pkg/controller/resource.go
@@ -497,7 +497,8 @@ func (c *Controller) rdsUpdate(ctx context.Context, client *golangsdk.ServiceCli
 			Jobs(newRds.Namespace).
 			Create(ctx, job, metav1.CreateOptions{})
 
-		_, err = c.kubeClientSet.BatchV1().Jobs(newRds.Namespace).Watch(ctx, metav1.ListOptions{Watch: true, LabelSelector: newRds.Name})
+		labelSelect := "job-name=" + newRds.Name
+		_, err = c.kubeClientSet.BatchV1().Jobs(newRds.Namespace).Watch(ctx, metav1.ListOptions{Watch: true, LabelSelector: labelSelect})
 		_ = tokens.Revoke(client, token.ID)
 
 		if err != nil {

--- a/pkg/controller/resource.go
+++ b/pkg/controller/resource.go
@@ -519,22 +519,24 @@ func (c *Controller) rdsUpdate(ctx context.Context, client *golangsdk.ServiceCli
 		for {
 			select {
 			case event := <-events:
-				// revoke OTC Auth Token for job
-				_ = tokens.Revoke(client, token.ID)
 				if event.Object == nil {
+					_ = tokens.Revoke(client, token.ID)
 					err := fmt.Errorf("error on result channel logfetch job: %v", err)
 					return err
 				}
 				k8sJob, ok := event.Object.(*batch.Job)
 				if !ok {
+					_ = tokens.Revoke(client, token.ID)
 					err := fmt.Errorf("error on object logfetch job: %v", err)
 					return err
 				}
 				conditions := k8sJob.Status.Conditions
 				for _, condition := range conditions {
 					if condition.Type == batch.JobComplete {
+						_ = tokens.Revoke(client, token.ID)
 						return nil
 					} else if condition.Type == batch.JobFailed {
+						_ = tokens.Revoke(client, token.ID)
 						err := fmt.Errorf("logfetch job for %s failed", newRds.Name)
 						return err
 					}

--- a/pkg/controller/resource.go
+++ b/pkg/controller/resource.go
@@ -497,6 +497,7 @@ func (c *Controller) rdsUpdate(ctx context.Context, client *golangsdk.ServiceCli
 			Jobs(newRds.Namespace).
 			Create(ctx, job, metav1.CreateOptions{})
 
+		_, err = c.kubeClientSet.BatchV1().Jobs(newRds.Namespace).Watch(ctx, metav1.ListOptions{Watch: true, LabelSelector: newRds.Name})
 		_ = tokens.Revoke(client, token.ID)
 
 		if err != nil {

--- a/pkg/controller/resource.go
+++ b/pkg/controller/resource.go
@@ -516,11 +516,11 @@ func (c *Controller) rdsUpdate(ctx context.Context, client *golangsdk.ServiceCli
 		}
 
 		events := watch.ResultChan()
-		// revoke OTC Auth Token for job
-		_ = tokens.Revoke(client, token.ID)
 		for {
 			select {
 			case event := <-events:
+				// revoke OTC Auth Token for job
+				_ = tokens.Revoke(client, token.ID)
 				if event.Object == nil {
 					err := fmt.Errorf("error on result channel logfetch job: %v", err)
 					return err
@@ -540,6 +540,8 @@ func (c *Controller) rdsUpdate(ctx context.Context, client *golangsdk.ServiceCli
 					}
 				}
 			case <-ctx.Done():
+				// revoke OTC Auth Token for job
+				_ = tokens.Revoke(client, token.ID)
 				err := fmt.Errorf("logfetch job %s cancelled", newRds.Name)
 				return err
 			}


### PR DESCRIPTION
Prevent leaking cloud credentions to userland. 
* Create a token on behalf of rdsoperator
* Doing job for logfetch
* Revoke token when finished.